### PR TITLE
Only emit descriptions for solid up to null (fixes issue #2)

### DIFF
--- a/stl.js
+++ b/stl.js
@@ -221,9 +221,9 @@ module.exports = {
               return;
             }
 
-            if (data.indexOf('solid') > -1) {
+            if (data.match(/^\s*solid/)) {
               stream.queue({
-                description : data.trim().split(' ').slice(1).join(' ')
+                description : data.match(/solid\s+([^\0]*)/)[1].trim()
               });
 
             } else if (data.indexOf('endfacet') > -1) {


### PR DESCRIPTION
The change to the condition is necessary to fix another bug (that lines like "endsolid" would trigger another description emit) that caused tests to fail with the change on line 226.