### PR TITLE
make description optional

### DIFF
--- a/stl.js
+++ b/stl.js
@@ -58,7 +58,7 @@ module.exports = {
 
     if (!binary) {
       var str = [
-        'solid ' + obj.description.trim()
+        obj.description? 'solid ' + obj.description.trim() : 'solid'
       ];
 
       var fl = obj.facets.length;


### PR DESCRIPTION
README says the "description" field is optional, but it throws an error if no description because it's trying to call a function on a string that doesn't exist.
Edited the package installed on my computer with this commit, works fine now
Fix #5 